### PR TITLE
Bug fixes: Stripped out binary blobs from display and prompt; increas…

### DIFF
--- a/src/logic/sql_query.py
+++ b/src/logic/sql_query.py
@@ -1,4 +1,5 @@
 import codecs
+import re
 from utils.bcolors import Bcolors
 
 class SqlQuery():
@@ -153,7 +154,10 @@ class SqlQuery():
             table_info += f"Table schema: {sql_result_schema}\n"
             table_info += f"Sample rows: {sql_result_sample_rows}\n"
             table_info += "</table_info>"
-            
+
+        ### Strip out binary blobs in the data which are useless to the LLM and dramatically slow down prompts
+        table_info = re.sub(r", b'\\.+?', ", ", BLOB_VALUE, ",table_info)
+
         print("Table info: ")
         print(table_info)
         print()

--- a/src/utils/llm.py
+++ b/src/utils/llm.py
@@ -1,4 +1,5 @@
 import boto3
+from botocore.config import Config
 from langchain_community.embeddings import BedrockEmbeddings
 import json
 
@@ -6,10 +7,14 @@ class LanguageModel():
     
     def __init__(self):
 
+        # Extend timeout to 90 seconds and don't retry if that fails
+        config = Config(retries={'max_attempts': 2}, read_timeout=30)
+
         # Create bedrock client
         bedrock_client = boto3.client(
             'bedrock-runtime',
             region_name='us-west-2',
+            config=config
             )
         self.bedrock_client = bedrock_client
 


### PR DESCRIPTION
Bug fixes: Stripped out binary blobs from display and prompt; increased bedrock timeout to 30 seconds and reduced retries to 2.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
